### PR TITLE
Upgrade packages to minimize the size of dependency graph

### DIFF
--- a/src/1 - Starter/RealEstate.csproj
+++ b/src/1 - Starter/RealEstate.csproj
@@ -15,16 +15,16 @@
 
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="5.0.3" />
-    <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.2.2" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.3">
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="5.0.8" />
+    <PackageReference Include="Microsoft.Azure.Storage.Blob" Version="11.2.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="5.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="5.0.8" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="5.0.8">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-    <PackageReference Include="X.PagedList.Mvc.Core" Version="8.0.7" />
+    <PackageReference Include="X.PagedList.Mvc.Core" Version="8.1.0" />
   </ItemGroup>
 
 


### PR DESCRIPTION
Hi@Krumelur, I found an issue in the RealEstate.csproj:

Packages Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore v5.0.3, Microsoft.Azure.Storage.Blob v11.2.2, Microsoft.EntityFrameworkCore v5.0.3, Microsoft.EntityFrameworkCore.SqlServer v5.0.3, Microsoft.EntityFrameworkCore.Tools v5.0.3 and X.PagedList.Mvc.Core v8.0.7 transitively introduce 173 dependencies into mslearn-live-migrating-to-the-cloud’s dependency graph ([see dependency graph before upgrades](http://202.182.124.107:8000/mslearn-live-migrating-to-the-cloud.html)), while Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore v5.0.8, Microsoft.Azure.Storage.Blob v11.2.3, Microsoft.EntityFrameworkCore v5.0.8 Microsoft.EntityFrameworkCore.SqlServer v5.0.8, Microsoft.EntityFrameworkCore.Tools v5.0.8 and X.PagedList.Mvc.Core v8.1.0 can only introduce 121 dependencies ([see dependency graph after upgrades](http://127.0.0.1:8000/mslearn-live-migrating-to-the-cloud_after.html)).

These upgrades can help project minimize the size of dependency graph.
Hope the PR can help you.

Best regards,
sucrose